### PR TITLE
Write a custom GLib transport / face

### DIFF
--- a/test_get_async.py
+++ b/test_get_async.py
@@ -59,5 +59,5 @@ if __name__ == "__main__":
         if args.limit and consumer._callbackCount > args.limit:
             loop.quit()
 
-    consumer.connect('face-process-event', check)
+    consumer.connect('data', check)
     loop.run()

--- a/test_publish_async_nfd.py
+++ b/test_publish_async_nfd.py
@@ -55,5 +55,5 @@ if __name__ == "__main__":
         if args.limit and producer._responseCount > args.limit:
             loop.quit()
 
-    producer.connect('face-process-event', check)
+    producer.connect('interest', check)
     loop.run()


### PR DESCRIPTION
This prevents us from doing a 100ms sleep and instead lets us poll on
the socket directly in the GLib mainloop.