### PR TITLE
T13934

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Philip Withnall <withnall@endlessm.com>
 Build-Depends:
  debhelper (>= 10),
  dh-python,
+ dh-systemd,
  python-all,
  python-pyndn,
  python-pytest,

--- a/debian/python-eos-data-distribution.install
+++ b/debian/python-eos-data-distribution.install
@@ -1,0 +1,3 @@
+eos_data_distribution/producers/70-edd-usb-producer.rules usr/lib/udev/rules.d
+eos_data_distribution/producers/edd-usb-producer.service lib/systemd/system
+

--- a/debian/rules
+++ b/debian/rules
@@ -4,3 +4,6 @@ export PYBUILD_DISABLE=test
 #export DH_VERBOSE = 1
 %:
 	dh $@ --with python2 --buildsystem=pybuild
+
+override_dh_install:
+	dh_install --fail-missing

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 export PYBUILD_DISABLE=test
 #export DH_VERBOSE = 1
 %:
-	dh $@ --with python2 --buildsystem=pybuild
+	dh $@ --with python2,systemd --buildsystem=pybuild
 
 override_dh_install:
 	dh_install --fail-missing

--- a/eos_data_distribution/MDNS/__init__.py
+++ b/eos_data_distribution/MDNS/__init__.py
@@ -70,7 +70,7 @@ class ServiceDiscovery(GObject.GObject):
             self.system_bus = dbus.SystemBus()
             self.system_bus.add_signal_receiver(self.avahi_dbus_connect_cb, "NameOwnerChanged", "org.freedesktop.DBus", arg0="org.freedesktop.Avahi")
         except dbus.DBusException as e:
-            pprint.pprint(e)
+            print("Failed to connect to the system bus: %s" % e.message)
             sys.exit(1)
 
         self.db = ServiceTypeDatabase()

--- a/eos_data_distribution/producers/70-edd-usb-producer.rules
+++ b/eos_data_distribution/producers/70-edd-usb-producer.rules
@@ -1,0 +1,5 @@
+ACTION!="add", GOTO="edd_usb_producer_end"
+
+ACTION=="add", SUBSYSTEM=="block", TAG+="systemd", ENV{SYSTEMD_WANTS}="edd-usb-producer.service"
+
+LABEL="edd_usb_producer_end"

--- a/eos_data_distribution/producers/edd-usb-producer.service
+++ b/eos_data_distribution/producers/edd-usb-producer.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=EDD USB Producer
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/edd-usb-producer
+Restart=on-abort
+Environment=GIO_USE_VFS=local
+Environment=GVFS_DISABLE_FUSE=1
+Environment=GVFS_REMOTE_VOLUME_MONITOR_IGNORE=1
+CapabilityBoundingSet=
+PrivateNetwork=yes
+PrivateDevices=yes
+ProtectSystem=full
+ProtectHome=yes
+PrivateTmp=yes
+NoNewPrivileges=yes

--- a/eos_data_distribution/producers/usb.py
+++ b/eos_data_distribution/producers/usb.py
@@ -42,10 +42,8 @@ IDLE_TIMEOUT = 30  # seconds
 
 
 def is_mount_interesting(mount):
-    """Is the given mount interesting: does it have an associated drive,
-       and does it contain NDN cache data?"""
-    return (mount.get_drive() and
-            path.exists(path.join(mount.get_root().get_path(),
+    """Is the given mount interesting: does it contain NDN cache data?"""
+    return (path.exists(path.join(mount.get_root().get_path(),
                                   ENDLESS_NDN_CACHE_PATH)))
 
 
@@ -54,12 +52,11 @@ def mount_added_cb(monitor, mount, store):
         return logger.warning("No NDN data found on %s (%s)",
                               mount.get_name(), mount.get_uuid() or "no UUID")
 
-    drive = mount.get_drive()
     root = mount.get_root()
     base = path.join(root.get_path(), ENDLESS_NDN_CACHE_PATH)
 
     logger.info("Starting import from %s (%s)",
-                drive.get_name(), drive.get_identifier() or "no identifier")
+                mount.get_name(), mount.get_uuid() or "no UUID")
     store.publish_all_names(base)
 
 

--- a/eos_data_distribution/producers/usb.py
+++ b/eos_data_distribution/producers/usb.py
@@ -64,7 +64,7 @@ def mount_added_cb(monitor, mount, store):
 def mount_removed_cb(monitor, mount, store):
     root = mount.get_root()
     root_path = root.get_path()
-    pprint.pprint([store.remove_name(n) for p, n in store.producers.items() if p.startswith(root_path)])
+    pprint.pprint([store.remove_name(n) for p, n in store.dirpubs.items() if p.startswith(root_path)])
     maybe_time_out()
 
 

--- a/eos_data_distribution/producers/usb.py
+++ b/eos_data_distribution/producers/usb.py
@@ -60,8 +60,8 @@ def mount_added_cb(monitor, mount, store):
 
 def mount_removed_cb(monitor, mount, store):
     root = mount.get_root()
-    p = root.get_path()
-    pprint.pprint([store.remove_name(n) for p, n in store.producers.items() if p.startswith(p)])
+    root_path = root.get_path()
+    pprint.pprint([store.remove_name(n) for p, n in store.producers.items() if p.startswith(root_path)])
 
 
 def main():

--- a/eos_data_distribution/producers/usb.py
+++ b/eos_data_distribution/producers/usb.py
@@ -20,6 +20,7 @@
 import logging
 import pprint
 from os import path
+import signal
 import sys
 
 import gi
@@ -94,8 +95,16 @@ def timeout_cb():
     return GLib.SOURCE_REMOVE
 
 
+def signal_cb():
+    logger.info("Exiting on signal")
+    sys.exit(0)
+
+
 def main():
     loop = GLib.MainLoop()
+
+    GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGINT, signal_cb)
+    GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, signal_cb)
     monitor = Gio.VolumeMonitor.get()
     store = SimpleStoreProducer(prefix=SUBSCRIPTIONS_SOMA, split=ENDLESS_NDN_CACHE_PATH)
 

--- a/eos_data_distribution/producers/usb.py
+++ b/eos_data_distribution/producers/usb.py
@@ -18,7 +18,6 @@
 # A copy of the GNU Lesser General Public License is in the file COPYING.
 
 import logging
-import pprint
 from os import path
 import signal
 import sys
@@ -64,7 +63,8 @@ def mount_added_cb(monitor, mount, store):
 def mount_removed_cb(monitor, mount, store):
     root = mount.get_root()
     root_path = root.get_path()
-    pprint.pprint([store.remove_name(n) for p, n in store.dirpubs.items() if p.startswith(root_path)])
+    removed_names = [store.remove_name(n) for p, n in store.dirpubs.items() if p.startswith(root_path)]
+    logger.debug("Removed names: %s" % removed_names)
     maybe_time_out()
 
 

--- a/eos_data_distribution/producers/usb.py
+++ b/eos_data_distribution/producers/usb.py
@@ -44,10 +44,12 @@ def mount_added_cb(monitor, mount, store):
         pprint.pprint(drive.get_name())
 
     if path.exists(base):
-        logger.info("Starting import")
+        logger.info("Starting import from %s (%s)",
+                    drive.get_name(), drive.get_identifier())
         store.publish_all_names(base)
     else:
-        logger.warning("No NDN data found !")
+        logger.warning("No NDN data found on %s (%s)",
+                       drive.get_name(), drive.get_identifier())
 
 
 def mount_removed_cb(monitor, mount, store):


### PR DESCRIPTION
The first round of changes needed for [T13934](https://phabricator.endlessm.com/T13934), to add a systemd `.service` file and udev integration for `edd-usb-producer` so that it runs when a USB stick is plugged in.

It will now run when a new block device appears, and will automatically quit after 30s if there are no interesting mounts around (and if no content is currently published from any mounts).

I have done some basic testing with a USB stick containing an empty `.endless-NDN-DATA` directory to check the system integration; but I have not yet put together a full `.endless-NDN-DATA` directory and tested it that way. I will do that and submit any resulting fixes as a separate PR, as they are less to do with the system integration.