### PR TITLE
Add desktop files to prompt app updates

### DIFF
--- a/debian/prensa-libre-updater.desktop
+++ b/debian/prensa-libre-updater.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=Prensa Libre Updater
+Exec=dbus-send --session --type=method_call --dest=com.endlessm.EknSubscriptionsDownloader /com/endlessm/EknSubscriptionsDownloader com.endlessm.EknSubscriptionsDownloader.DownloadSubscription string:10521bb3a18b573f088f84e59c9bbb6c2e2a1a67
+Icon=software-update-available
+Terminal=false

--- a/debian/python-eos-data-distribution.install
+++ b/debian/python-eos-data-distribution.install
@@ -5,3 +5,5 @@ debian/edd-ostree-store.service lib/systemd/system
 debian/edd-soma-subscriptions-producer.service lib/systemd/system
 debian/edd-usb-producer.service lib/systemd/system
 debian/eos-data-distribution.conf usr/lib/tmpfiles.d
+debian/soy502-updater.desktop usr/share/applications
+debian/prensa-libre-updater.desktop usr/share/applications

--- a/debian/soy502-updater.desktop
+++ b/debian/soy502-updater.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=Soy502 Updater
+Exec=dbus-send --session --type=method_call --dest=com.endlessm.EknSubscriptionsDownloader /com/endlessm/EknSubscriptionsDownloader com.endlessm.EknSubscriptionsDownloader.DownloadSubscription string:cb040a5004342a3e6fbbe38d4933b3517e8ca5e79b0f5efa3329d503490c506d
+Icon=software-update-available
+Terminal=false


### PR DESCRIPTION
These are hardcoded for the two demo apps, Soy502 and Prensa Libre