### PR TITLE
updaters: use gdbus instead of dbus-send

### DIFF
--- a/debian/prensa-libre-updater.desktop
+++ b/debian/prensa-libre-updater.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
 Name=Prensa Libre Updater
-Exec=dbus-send --session --type=method_call --dest=com.endlessm.EknSubscriptionsDownloader /com/endlessm/EknSubscriptionsDownloader com.endlessm.EknSubscriptionsDownloader.DownloadSubscription string:10521bb3a18b573f088f84e59c9bbb6c2e2a1a67
+Exec=gdbus call --session --dest=com.endlessm.EknSubscriptionsDownloader --object-path=/com/endlessm/EknSubscriptionsDownloader --method=com.endlessm.EknSubscriptionsDownloader.DownloadSubscription 10521bb3a18b573f088f84e59c9bbb6c2e2a1a67
 Icon=software-update-available
 Terminal=false

--- a/debian/soy502-updater.desktop
+++ b/debian/soy502-updater.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
 Name=Soy502 Updater
-Exec=dbus-send --session --type=method_call --dest=com.endlessm.EknSubscriptionsDownloader /com/endlessm/EknSubscriptionsDownloader com.endlessm.EknSubscriptionsDownloader.DownloadSubscription string:cb040a5004342a3e6fbbe38d4933b3517e8ca5e79b0f5efa3329d503490c506d
+Exec=gdbus call --session --dest=com.endlessm.EknSubscriptionsDownloader --object-path=/com/endlessm/EknSubscriptionsDownloader --method=com.endlessm.EknSubscriptionsDownloader.DownloadSubscription cb040a5004342a3e6fbbe38d4933b3517e8ca5e79b0f5efa3329d503490c506d
 Icon=software-update-available
 Terminal=false


### PR DESCRIPTION
We were seeing some issues with the edd-dbus-service launching but not
handling methods when invoking it with dbus-send. Using gdbus seems to
solve this by starting the service and then sending the method
invocation. We should probably fix this at some point...